### PR TITLE
Use bound requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "neemzy/share-extension",
     "description": "Twig extension providing social share links",
-    "minimum-stability": "dev",
 
     "authors": [
         {
@@ -12,7 +11,7 @@
 
     "require": {
         "php": ">=5.4.0",
-        "dunglas/php-socialshare": "dev-master"
+        "dunglas/php-socialshare": "~0.2"
     },
 
     "autoload": {


### PR DESCRIPTION
I also removed the minimum stability. This would force the testsuite to install dependencies with the normal minimum-stability restriction, matching better the actual usage of the library (I see that all your packages are actually incompatible with releases as they almost all depend on dev-master versions of other components, but this is something you should change)

Closes #3 
